### PR TITLE
Added python requests as a dependency

### DIFF
--- a/rapp_email/package.xml
+++ b/rapp_email/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>python-requests</depend>
   <depend>rospy</depend>
   <depend>rapp_utilities</depend>
   <depend>rapp_platform_ros_communications</depend>


### PR DESCRIPTION
@130s as per our discussion on gitlab, adding python-requests as a dependency.

I uninstalled my pip version, and ran the service node and it failed as expected.

Then ran rosdep install with this change and the node runs again on 16.04.

Please review.